### PR TITLE
add flake to build binary

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,31 @@
+name: Nix Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  nix-build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Check flake
+        run: nix flake check
+
+      - name: Build with Nix
+        run: nix build .#polykill
+
+      - name: Test Nix build
+        run: ./result/bin/polykill --help

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# ignore nix build `result` symlink
+result

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ brew tap bdeering1/polykill
 brew install polykill
 ```
 
+**Nix flake**
+
+```sh
+# Run directly
+nix run github:Bdeering1/polykill
+
+# Add to ephemeral shell
+nix shell github:Bdeering1/polykill
+```
+
 ## Usage
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Command line utility for removing dependencies and build artifacts from unused projects.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+      flake-utils.lib.eachDefaultSystem (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        in
+        {
+          packages = rec {
+            polykill = pkgs.rustPlatform.buildRustPackage {
+                pname = cargoToml.package.name;
+                version = cargoToml.package.version;
+
+                src = ./.;
+
+                cargoHash = "sha256-OWNS8c8f6n/17mORbCMnI0qmOJftkwTHl+X1PB8c5bU=";
+
+                meta = {
+                  description = cargoToml.package.description;
+                  homepage = cargoToml.package.repository;
+                };
+            };
+            default = polykill;
+          };
+        }
+      );
+}


### PR DESCRIPTION
This PR adds a `flake.nix` that can build polykill by running `nix build`. Since it is a flake, it can be easily imported into other nix projects.

Also added is a `nix.yaml` github actions workflow that runs the nix build on push/PR to main, ensuring changes to the code don't break the build (this will catch when `cargoHash` needs to be updated.